### PR TITLE
Adds the ability to use a variable: cloud_init_script to pass the path to a cloud-init script to the instance module

### DIFF
--- a/cd3_automation_toolkit/user-scripts/terraform/instance.tf
+++ b/cd3_automation_toolkit/user-scripts/terraform/instance.tf
@@ -52,6 +52,8 @@ module "instances" {
 
   boot_tf_policy           = each.value.backup_policy != null ? each.value.backup_policy : null
   policy_tf_compartment_id = each.value.policy_compartment_id != null ? (length(regexall("ocid1.compartment.oc1*", each.value.policy_compartment_id)) > 0 ? each.value.policy_compartment_id : var.compartment_ocids[each.value.policy_compartment_id]) : null
+  cloud_init_script        = each.value.cloud_init_script
+
 
   ## Optional parameters to enable and test ##
   # extended_metadata    = each.value.extended_metadata

--- a/cd3_automation_toolkit/user-scripts/terraform/modules/compute/instance/main.tf
+++ b/cd3_automation_toolkit/user-scripts/terraform/modules/compute/instance/main.tf
@@ -21,6 +21,7 @@ resource "oci_core_instance" "instance" {
   is_pv_encryption_in_transit_enabled = var.create_is_pv_encryption_in_transit_enabled
   metadata = {
     ssh_authorized_keys = var.ssh_public_keys
+    user_data = var.cloud_init_script != null ? "${base64encode(file(var.cloud_init_script))}" : null
   }
   preserve_boot_volume = var.preserve_boot_volume
 

--- a/cd3_automation_toolkit/user-scripts/terraform/modules/compute/instance/variables.tf
+++ b/cd3_automation_toolkit/user-scripts/terraform/modules/compute/instance/variables.tf
@@ -309,3 +309,8 @@ variable "vnic_freeform_tags" {
   type    = map(string)
   default = {}
 }
+
+variable "cloud_init_script" {
+  type    = string
+  default = null
+}

--- a/cd3_automation_toolkit/user-scripts/terraform/scripts/example.ps1
+++ b/cd3_automation_toolkit/user-scripts/terraform/scripts/example.ps1
@@ -1,0 +1,1 @@
+Write-Output 'Hello, World!'

--- a/cd3_automation_toolkit/user-scripts/terraform/scripts/example.sh
+++ b/cd3_automation_toolkit/user-scripts/terraform/scripts/example.sh
@@ -1,0 +1,1 @@
+echo "Hello, World!"

--- a/cd3_automation_toolkit/user-scripts/terraform/variables_example.tf
+++ b/cd3_automation_toolkit/user-scripts/terraform/variables_example.tf
@@ -612,6 +612,7 @@ variable "instances" {
     vcn_name                  = string
     subnet_id                 = string
     network_compartment_id    = string
+    cloud_init_script         = optional(string)
     display_name              = optional(string)
     assign_public_ip          = optional(bool)
     boot_volume_size_in_gbs   = optional(string)


### PR DESCRIPTION
We wanted to enable a cloud-init() script to be run during instance creation from the CD3 generated terraform code. This is a simple addition that allows users to specify a cloud-init script in their auto.tfvars files.

Example: 

```terraform
  example_instance =  {
            availability_domain  = 0
            compartment_id       = "compartment-name"
            shape                = "VM.Standard.E4.Flex"
            display_name         = "example"
            fault_domain         = "FAULT-DOMAIN-1"
            source_id        =  "OLinux86"
            source_type      = "image"
            network_compartment_id = "network-compartment"
            vcn_name         = "example-vcn"
            subnet_id        = "example-subnet"
            assign_public_ip = false
            ocpus            = "2"
            memory_in_gbs = 16
            create_is_pv_encryption_in_transit_enabled = true
            ssh_authorized_keys  = "ssh_public_key"
            backup_policy          = "Gold"
            cloud_init_script = "./scripts/example.sh"
    },
```