### PR TITLE
Add Dependabot configuration (GitHub Actions + Docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
This PR adds a repository-level Dependabot configuration file:

- `.github/dependabot.yml`

Configured ecosystems:
- `github-actions` (directory `/`, weekly)
- `docker` (directory `/`, weekly)

Additional setting:
- `open-pull-requests-limit: 5`

Why:
- Enable file-based Dependabot version updates for the ecosystems currently present in this repository.
- Keep dependencies and GitHub Actions versions updated on a regular schedule.