### PR TITLE
Add CodeQL scanning workflow

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,0 +1,8 @@
+﻿# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+name: CodeQL configuration
+paths:
+- cd3_automation_toolkit
+- othertools
+- .github/workflows

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,52 @@
+﻿# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+# Run CodeQL over the repository. For more configuration options see .github/codeql/codeql-config.yaml
+# and: https://github.com/github/codeql-action
+
+name: CodeQL
+on:
+  push:
+    branches:
+    - main
+    - develop
+  pull_request:
+    branches:
+    - main
+    - develop
+  schedule:
+  - cron: 20 15 * * 3
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        language: [python, actions]
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
+      with:
+        languages: ${{ matrix.language }}
+        config-file: .github/codeql/codeql-config.yaml
+        # Override the default behavior so that the action doesn't attempt
+        # to auto-install Python dependencies.
+        setup-python-dependencies: false
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
+      


### PR DESCRIPTION
Adds CodeQL workflow and configuration under `.github/` for GitHub-native code scanning.

This is based on the recommended Macaron example and adapted for the CD3 Automation Toolkit repository.