### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+# This configuration enables Dependabot version updates.
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
+
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 5
+  target-branch: main
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 5
+  target-branch: main
+
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 5
+  target-branch: main


### PR DESCRIPTION
Adds Dependabot configuration for GitHub Actions, Python/pip dependencies, and Docker updates.

This follows the recommended GitHub-native dependency update setup and is adapted for the CD3 Automation Toolkit repository.

Dependabot will check weekly and open PRs when supported dependencies or GitHub Actions versions can be updated.