### PR TITLE
Add Macaron analysis workflow

### DIFF
--- a/.github/workflows/macaron-analysis.yaml
+++ b/.github/workflows/macaron-analysis.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+# Run Macaron's policies and generate Verification Summary Attestation reports.
+# See https://github.com/oracle/macaron
+
+name: Run Macaron to check supply chain security issues
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+  pull_request:
+    paths:
+      - .github/workflows/**
+  schedule:
+    - cron: 20 15 * * 3
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run_macaron:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Check the GitHub Actions workflows in the repository for vulnerabilities.
+      # Note: policy_purl is adapted for the CD3 Automation Toolkit repository.
+      - name: Run Macaron action
+        id: run_macaron
+        continue-on-error: true
+        uses: oracle/macaron@4ddb55e3c9ef2c77b548be55c557078c4476fd9c # v0.24.0
+        with:
+          repo_path: ./
+          policy_file: check-github-actions
+          policy_purl: pkg:github.com/oracle-devrel/cd3-automation-toolkit@.*
+          reports_retention_days: 3


### PR DESCRIPTION
Adds a Macaron workflow to analyze GitHub Actions workflows, Dockerfile changes, and shell scripts for supply-chain security issues.

This follows the recommended GitHub-native security hardening setup and is adapted for the CD3 Automation Toolkit repository.

The workflow runs on:
- pushes to `main` affecting workflows, Dockerfile, or shell scripts
- pull requests affecting workflows, Dockerfile, or shell scripts
- a weekly schedule
- manual dispatch from GitHub Actions